### PR TITLE
Improve compatibility with v3.3.2

### DIFF
--- a/masonry-v2-3-shim.js
+++ b/masonry-v2-3-shim.js
@@ -24,7 +24,7 @@
     var isAniOption = this.options.isAnimated;
     if ( isAniOption !== undefined ) {
       this.options.transitionDuration = isAniOption ?
-        Masonry.prototype.options.transitionDuration : 0;
+        this.options.transitionDuration : 0;
     }
 
     if ( isAniOption === undefined || isAniOption ) {


### PR DESCRIPTION
`Masonry.prototype.options` is no longer defined, `this.options` is and does the same.

See https://core.trac.wordpress.org/ticket/37666.
